### PR TITLE
refactor: .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node modules
 node_modules/
 
+# Environment variables
+.env
+
 # Yarn logs
 yarn-error.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-<<<<<<< HEAD
-node_modules
-=======
-node_modules
-/node_modules
->>>>>>> c210e1d8be5145a4a9e605113991421270d7683f
+# Node modules
+node_modules/
+
+# Yarn logs
+yarn-error.log
+
+# VSCode garbage
+.vscode/


### PR DESCRIPTION
The `.gitignore` in the repository currently contains the remnants of an unresolved merge conflict. This PR refactors the `.gitignore` to better suit the project's needs.